### PR TITLE
Update TX2 installation + PS4 pairing instructions

### DIFF
--- a/doc/jetson.rst
+++ b/doc/jetson.rst
@@ -75,7 +75,20 @@ When the Jetson starts up again, it should be connected to the Jackal. To see th
 
 Your Jetson TX2 should now be configured to operate as the Jackal's main PC.  See :doc:`Extending Jackal Startup <startup>` for more on how to configure Jackal's accessories.
 
-If you would like to pair a PS4 controller to drive the Jackal, hold down the PS and Share buttons on the controller until the light bar starts to flash. In a terminal on the Jackal, run ``sudo ds4drv-pair`` and wait for the controller to connect.  With the controller paired you should be able to control the Jackal by pressing L1 and using the left stick to drive. For more information see the Jackal manual.
+If you would like to pair a PS4 controller to drive the Jackal, hold down the PS and Share buttons on the controller until the light bar starts to flash. In a terminal on the Jackal, run ``bluetoothctl`` and then run the following commands:
+
+.. code-block:: text
+
+    agent on
+    scan on
+    < look for the MAC address of your controller; it will be identified by "Wireless Controller" or similar text >
+    scan off
+    pair <MAC ADDRESS>
+    trust <MAC ADDRESS>
+    connect <MAC ADDRESS>
+    < ctrl + d to exit >
+
+The light on the controller will turn solid blue once it is paired. With the controller paired you should be able to control the Jackal by pressing L1 and using the left stick to drive. For more information see the Jackal manual.
 
 To use your host computer with the Jackal first `install ROS <http://wiki.ros.org/|ros_distro|/Installation>`_ and `setup a catkin workspace <http://wiki.ros.org/catkin/Tutorials/create_a_workspace>`_. Clone the general Jackal repo and the desktop specific repo in to the src folder and compile them, installing rosdeps if necessary:
 

--- a/doc/jetson.rst
+++ b/doc/jetson.rst
@@ -37,47 +37,58 @@ In order to power the Jetson make a cable which connects to the 12V user power t
 Step 3: Installing the software
 --------------------------------
 
-On a Ubuntu machine download jetpack 3.3.
+`Download the latest version of Nvidia's SDK Manager <https://developer.nvidia.com/nvidia-sdk-manager>`_ on a PC running Ubuntu 18.04.  While that's downloading, put the TX2 into reovery mode by following these steps:
 
-`Download Jetpack <https://developer.nvidia.com/embedded/dlc/jetpack-l4t-3_3>`_
+1.  Connect the TX2 to your PC using the provided microUSB cable.
+2.  Make sure the TX2 is powered off
+3.  Connect a monitor, mouse, and keyboard to the Jetson.  (The mouse is optional, but recommended.  If you do not have an all-in-one mouse+keyboard you will need to use a small USB hub, as the Jetson TX2 only has a single USB port.)
+4.  Press and hold the REC button
+5.  Press the power button.
 
-`Jetpack Install Instructions <https://docs.nvidia.com/jetson/archives/jetpack-archived/jetpack-321/index.html#jetpack/3.2.1/install.htm%3FTocPath%3D_____3>`_
+Install the SDK Manager by running the following commands:
 
-Follow the installation instructions from Nvidia to start the installer. Install at least the Linux for Tegra Host Side Image Setup.
+.. code-block:: bash
 
-.. image:: minimuminstall.png
-
-`Download the TX2 image <https://s3.amazonaws.com/cprjetsonimages/TX2/TX2_28.2.1.img.raw.bz2>`_ and place it into "{install directory}/64_TX2/Linux_for_Tegra_tx2/".  Open a terminal and navigate to "{install directory}/64_TX2/Linux_for_Tegra_tx2/". Use pbzip2 to decompress the image. "pbzip2 -d {image name}.img.bz2". Pbzip2 is the parallel version of bzip2. Unziping can take some time.
-
-**Caution:** you will need 32 GB of free space for the image. Copy the uncompressed image and rename it to "bootloader/system.img".
-
-.. note::
-  To verify the download, below are the MD5 sums of the download and the extracted image:
-
-  * 10bd148c346f8be4b02218e301b6dc4d  -  TX2_28.2.1.img.raw.bz2
-  * f4efc8b1a65a8d5f9465d4521188dd5e  -  TX2_28.2.1.img.raw
-
-Connect to the TX2 with a micro USB cable to the USB0 port. Power the TX2 either by turning on the Jackal or using the included power supply Next put the TX2 into recovery mode.
-
-1.  Make sure the TX2 is powered off
-2.  Press and hold the REC button
-3.  Press the power button.
-
-Then run ``sudo ./flash.sh -r -k APP jetson-tx2 mmcblk0p1`` on the host computer. this will copy the image file to the device. This is over USB2.0 so it will take some time.
-
-.. image:: flashcomplete.png
-
-The TX2 will reboot and will have ROS Kinetic installed along with the Jackal drivers.
+    cd <folder where you downloaded SDK manager>
+    sudo dpkg -i sdkmanager_<version>_amd64.deb
 
 .. note::
-  Since this image was created, the ROS buildfarm has changed their package-signing key.  You will need to add the new one with:
 
-  ``sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654``
+    If your system is missing dependencies you may see error messages in the output of the ``dpkg`` command.  To resolve these, run ``sudo apt-get -f install``.
 
-To setup the Jetson to work with the Jackal, run ``bash ~/JACKAL_SETUP.sh`` on the Jetson and restart. When the Jetson starts up again, it should be connected to the Jackal. To see that the Jackal is connected by opening a terminal and executing "rostopic echo /status". You should see a 1hz message containing the Jackal's diagnostic information.
+Once SDK Manager is installed, run it with the ``sdkmanager`` command.  `Follow SDK Manager's instructions <https://docs.nvidia.com/sdk-manager/install-with-sdkm-jetson/index.html>`_ to install the operating system and Nvidia components on your Jetson TX2.  During installation you will be asked to configure the login information on the Jetson.  To do this, use the monitor & keyboard you connected before to enter the username and password you want to use.
+
+.. note::
+
+    For compatibility with older versions of the Jetson TX2 software, we recommend setting the username and password to ``nvidia``.
+
+Once the OS has been written to the TX2, log into it and run the following commands to configure it for use with Jackal:
+
+.. code-block:: bash
+
+    curl -s https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/melodic/scripts/tx2_setup.sh | bash -s --
+    bash JACKAL_SETUP.sh
+
+These commands will download and install ROS along with the necessary APT packages to get Jackal up and running.  Depending on your network speed it may take a long time for everything to install.  Reboot the TX2 after these commands are done to complete the configuration.
+
+When the Jetson starts up again, it should be connected to the Jackal. To see that the Jackal is connected by opening a terminal and executing "rostopic echo /status". You should see a 1hz message containing the Jackal's diagnostic information.
+
+Your Jetson TX2 should now be configured to operate as the Jackal's main PC.  See :doc:`Extending Jackal Startup <startup>` for more on how to configure Jackal's accessories.
 
 If you would like to pair a PS4 controller to drive the Jackal, hold down the PS and Share buttons on the controller until the light bar starts to flash. In a terminal on the Jackal, run ``sudo ds4drv-pair`` and wait for the controller to connect.  With the controller paired you should be able to control the Jackal by pressing L1 and using the left stick to drive. For more information see the Jackal manual.
 
-To use your host computer with the Jackal first install ROS (http://wiki.ros.org/melodic/Installation) and setup a catkin workspace (http://wiki.ros.org/catkin/Tutorials/create_a_workspace). Clone the general Jackal repo and the desktop specific repo in to the src folder and compile it. Installing rosdeps if necessary with "rosdep install --from-paths src --ignore-src -r -y". https://github.com/jackal/jackal and https://github.com/jackal/jackal_desktop. Note the network ip of the TX2 and setup your host computer to use it as the master. http://wiki.ros.org/ROS/Tutorials/MultipleMachines
+To use your host computer with the Jackal first `install ROS <http://wiki.ros.org/|ros_distro|/Installation>`_ and `setup a catkin workspace <http://wiki.ros.org/catkin/Tutorials/create_a_workspace>`_. Clone the general Jackal repo and the desktop specific repo in to the src folder and compile them, installing rosdeps if necessary:
 
-You can then run "roslaunch jackal_viz view_robot.launch" on your host machine.  You should see a model of the robot and be able to move the Jackal using the interactive markers. See: http://www.clearpathrobotics.com/assets/guides/jackal/navigation.html
+.. code-block:: bash
+
+    cd src
+    git clone -b melodic-devel https://github.com/jackal/jackal
+    git clone -b melodic-devel https://github.com/jackal/jackal_desktop.
+    cd ..
+    rosdep install --from-paths src --ignore-src -r -y
+    catkin_make
+    source devel/setup.bash
+
+Note the IP address of the TX2 and `setup your host computer <http://wiki.ros.org/ROS/Tutorials/MultipleMachines>`_ to use it as the master.
+
+You can then run ``roslaunch jackal_viz view_robot.launch`` on your host machine.  You should see a model of the robot and be able to move the Jackal using the interactive markers. See: :doc:`Navigating with Jackal <navigation>` for more information on using maps for navigation and localization.


### PR DESCRIPTION
Note that these instructions rely on the update to the jetson_setup script specified here: clearpathrobotics/jetson_setup#4